### PR TITLE
Avoid inserting ZWS into colour codes

### DIFF
--- a/modules/irclog.js
+++ b/modules/irclog.js
@@ -13,7 +13,7 @@ function convertAgToIRC (str) {
 
 function preventHilight (str) {
   return str
-    .replace(/([ <+%@&~])([a-zA-Z0-9_])([a-zA-Z0-9_]+)/g, '$1$2\u200b$3')
+    .replace(/([ <+%@&~][a-zA-Z0-9_])([a-zA-Z0-9_]+)/g, '$1\u200b$2')
 }
 
 function processAg (str) {

--- a/modules/irclog.js
+++ b/modules/irclog.js
@@ -13,7 +13,7 @@ function convertAgToIRC (str) {
 
 function preventHilight (str) {
   return str
-    .replace(/(\b|[+%@&~])([a-zA-Z0-9_])([a-zA-Z0-9_]+)/g, '$1$2\u200b$3')
+    .replace(/([ <+%@&~])([a-zA-Z0-9_])([a-zA-Z0-9_]+)/g, '$1$2\u200b$3')
 }
 
 function processAg (str) {


### PR DESCRIPTION
This may result in people being pinged if their nick matches the search term, but they probably got pinged by the original `!ag` call anyway.