### PR TITLE
Remove unused dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "moment-countdown": "0.0.3",
     "moment-timezone": "^0.5.11",
     "node-ddg-api": "^0.1.4",
-    "npm": "^3.5.2",
+    "npm": "^5.7.1",
     "parse5": "^3.0.1",
     "rainbow-log": "^1.0.1",
     "request": "^2.67.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "youtube-search": "^1.0.4"
   },
   "devDependencies": {
-    "extract-comments": "^0.8.6",
     "jshint": "^2.5.4",
     "mocha": "^2.3.4",
     "node-dir": "^0.1.11",


### PR DESCRIPTION
We used it way back in 2a202f8ea9227925ab2ce6ce6635b9f981fc0ab1 to
automatically generate the readme file, but we don't do that now.

Resolves #91