### PR TITLE
Remove no longer needed before install step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
 language: node_js
-sudo: true
 node_js:
       - node
-before_install:
-    - sudo apt-get update -qq
-    - sudo apt-get install -y libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev
 notifications:
     irc:
         channels:


### PR DESCRIPTION
We needed to install some dependencies for the nudity module but we
removed it, so let's remove the install step to make the Travis build
faster.