### PR TITLE
Rework news module

### DIFF
--- a/config.js
+++ b/config.js
@@ -99,6 +99,11 @@ module.exports = config = convict({
     format: String
   },
   news: {
+    poll: {
+      doc: 'Whether to automatically poll for news',
+      format: Boolean,
+      default: true
+    },
     replace: {
       doc: 'Whether to enable xkcd style substitutions',
       format: Boolean,

--- a/modules/news.js
+++ b/modules/news.js
@@ -20,14 +20,14 @@ module.exports = {
     poll: {
       help: 'poll for news',
       privileged: true,
-      command: function (bot, msg) {
+      command: function () {
         plugin.pollApis(true)
         return 'ok'
       }
     },
     clearnews: {
       help: 'Clears the news cache',
-      command: function (bot, msg) {
+      command: function (bot) {
         oldnews = {}
         return 'News cache cleared. Take cover :)'
       }

--- a/modules/news.js
+++ b/modules/news.js
@@ -53,21 +53,22 @@ module.exports = {
      * and send it to the news event.
      */
     'rawnews:bbc': function (bot, story) {
-      if (story) {
+      if (story && story.headline) {
         bot.fireEvents('news', {
           color: 'dark_red',
           id: 'BBC' + story.assetId,
           text: story.headline,
           url: 'https://bbc.co.uk' + story.assetUri,
-          prompt: 'BREAKING'
+          prompt: 'BBC BREAKING'
         })
       }
     },
     'rawnews:reuters': function (bot, story) {
+      if (!story.headline) return
       bot.fireEvents('news', {
         color: 'orange',
         id: story.tag + story.headline,
-        prompt: story.label,
+        prompt: story.label ? story.label : 'Reuters',
         tail: story.tag ? story.tag : null,
         text: story.headline,
         url: story.url ? story.url : null

--- a/plugins/news.js
+++ b/plugins/news.js
@@ -66,11 +66,11 @@ const requestApi = (api) => {
     if (err) throw err
     let payload
     try {
-      if (res.body.trim() === '') res.body = '{}' // reuters sends empty on no news
-      payload = JSON.parse(res.body)
+      if (res.body.trim() === '') body = '{}' // reuters sends empty on no news
+      payload = JSON.parse(body)
     } catch (e) {
       if (!(e instanceof SyntaxError)) throw e
-      return console.log(`Syntax error decoding ${api.url}: ${payload} ${res.body}`)
+      return console.log(`Syntax error decoding ${api.url}: ${payload} ${body}`)
     }
     if (api.customDecoder) {
       payload = api.customDecoder(payload)
@@ -80,7 +80,6 @@ const requestApi = (api) => {
     }
     bot.fireEvents(`rawnews:${api.eventName}`, payload)
   })
-  setTimeout(poll, pollPeriod)
 }
 
 const pollApis = (skip) => {

--- a/plugins/news.js
+++ b/plugins/news.js
@@ -63,7 +63,7 @@ const APIS = [
 
 const requestApi = (api) => {
   request(api.url, (err, res, body) => {
-    if (err) throw err
+    if (err) return console.log(`Error polling ${api.url}: ${err}`)
     let payload
     try {
       if (res.body.trim() === '') body = '{}' // reuters sends empty on no news


### PR DESCRIPTION
* Remove `news` event handlers for previously removed `rawnews` APIs (Guardian, Independent)
* Collapse all the raw news functions down into one
* Add news poll command
* Add config option to disable automatic news polling

Closes #66 
Closes #72 
Contributes to #69