### PR TITLE
Add onunload module function

### DIFF
--- a/modules.js
+++ b/modules.js
@@ -58,7 +58,14 @@ var self = module.exports = {
     if (filename in require.cache) {
       const alreadyLoadedModule = require(file)
       if (alreadyLoadedModule.onunload) {
-        alreadyLoadedModule.onunload(bot)
+        try {
+          alreadyLoadedModule.onunload(bot)
+        } catch (e) {
+          // output error, but carry on anyway
+          console.error(`Error running ${file} onunload hook`)
+          console.error(e)
+          console.error(e.stack)
+        }
       }
     } else {
       // no module loaded -- don't bother unloading

--- a/modules.js
+++ b/modules.js
@@ -26,8 +26,7 @@ var self = module.exports = {
   },
   loadModule: function (bot, file) {
     try {
-      var filename = require.resolve(file)
-      delete require.cache[filename]
+      this.unloadModule(bot, file)
 
       var curr = require(file)
       if (curr.commands) {
@@ -51,6 +50,23 @@ var self = module.exports = {
       }
       return false
     }
+  },
+  unloadModule: function (bot, file) {
+    // check if module already loaded:
+    const filename = require.resolve(file)
+
+    if (filename in require.cache) {
+      const alreadyLoadedModule = require(file)
+      if (alreadyLoadedModule.onunload) {
+        alreadyLoadedModule.onunload(bot)
+      }
+    } else {
+      // no module loaded -- don't bother unloading
+      return
+    }
+
+    // delete the the module from cache:
+    delete require.cache[filename]
   },
   addCommands: function (bot, commands, clobber) {
     var keys = Object.keys(commands)

--- a/modules/README.md
+++ b/modules/README.md
@@ -160,13 +160,17 @@ Other events are available:
 * The `join` event runs whenever a user joins a channel (include the bot).
 * The `selfjoin` event runs whenever the bot joins a channel.
 
-## Onload
+## Onload and onunload
 The `onload` method is called on module load.
+The `onunload` method is called shortly before the module is reloaded.
 
 ```js
 module.exports = {
   onload: function () {
-    // code here will run on (re)load of method
+    // code here will run after (re)load of method
+  },
+  onunload: function () {
+    // code here will run immediately prior to reload of module
   }
 }
 ```


### PR DESCRIPTION
This commit adds an onunload module method in the same fashion as the
existing onload method. These aren't events.

This method will be run shortly before a module is (re)loaded if the
module was already loaded, in order to allow module authors to
gracefully tear down things they set up in the onload function, such as
timers.

It doesn't run on quit.

Fixes #152.