### PR TITLE
Countdown should round up, not down

### DIFF
--- a/modules/countdown.js
+++ b/modules/countdown.js
@@ -19,7 +19,7 @@ module.exports = {
     function autoCount (bot, lastTick) {
       const thisTick = moment('2019-03-29T23:00:00Z').countdown().toString().split(/, | and /)[0]
       if (thisTick !== lastTick) {
-        bot.broadcast('Article 50 expires in ' + thisTick)
+        bot.broadcast('Article 50 expires in ' + lastTick)
       }
       setTimeout(autoCount, 1000, bot, thisTick)
     }


### PR DESCRIPTION
When the automatic countdown reaches `14 days, 23 hours, 59 minutes and 59 seconds`, it should output `15 days`, but currently outputs `14 days`. This fixes that.