### PR TITLE
Add channel join event

### DIFF
--- a/modules/README.md
+++ b/modules/README.md
@@ -157,6 +157,8 @@ Other events are available:
     followed by the usual `message` arguments. Use `url.href` to get the raw URL.
   * The `url` event accepts arguments: `url:github.com` will only fire on URLs to that host.
 * The `news` and `rawnews` events (see `news.js`).
+* The `join` event runs whenever a user joins a channel (include the bot).
+* The `selfjoin` event runs whenever the bot joins a channel.
 
 ## Onload
 The `onload` method is called on module load.

--- a/modules/countdown.js
+++ b/modules/countdown.js
@@ -1,5 +1,16 @@
 var moment = require('moment')
 require('moment-countdown')
+
+let timeout = null
+
+function autoCount (bot, lastTick) {
+  const thisTick = moment('2019-03-29T23:00:00Z').countdown().toString().split(/, | and /)[0]
+  if (lastTick != null && thisTick !== lastTick) {
+    bot.broadcast('Article 50 expires in ' + thisTick)
+  }
+  timeout = setTimeout(autoCount, 1000, bot, thisTick)
+}
+
 module.exports = {
   commands: {
     a50: {
@@ -15,14 +26,10 @@ module.exports = {
       }
     }
   },
-  onload: function (bot) {
-    function autoCount (bot, lastTick) {
-      const thisTick = moment('2019-03-29T23:00:00Z').countdown().toString().split(/, | and /)[0]
-      if (thisTick !== lastTick) {
-        bot.broadcast('Article 50 expires in ' + lastTick)
-      }
-      setTimeout(autoCount, 1000, bot, thisTick)
+  events: {
+    selfjoin: function (bot) {
+      if (timeout !== null) return
+      autoCount(bot, null)
     }
-    autoCount(bot)
   }
 }

--- a/plugins/listeners.js
+++ b/plugins/listeners.js
@@ -18,7 +18,7 @@ bot.addListener('action', function (from, to, text, message) {
 
 bot.addListener('join', function (channel, nick, message) {
   bot.fireEvents('join', channel, nick, message)
-  if (nick == bot.nick) {
+  if (nick === bot.nick) {
     bot.fireEvents('selfjoin', channel, message)
   }
 })

--- a/plugins/listeners.js
+++ b/plugins/listeners.js
@@ -15,3 +15,10 @@ bot.addListener('ctcp-version', function (from, to, message) {
 bot.addListener('action', function (from, to, text, message) {
   bot.fireEvents('action', from, to, text, message)
 })
+
+bot.addListener('join', function (channel, nick, message) {
+  bot.fireEvents('join', channel, nick, message)
+  if (nick == bot.nick) {
+    bot.fireEvents('selfjoin', channel, message)
+  }
+})

--- a/test/mockBot.js
+++ b/test/mockBot.js
@@ -13,7 +13,7 @@ module.exports = self = {
     self.channel = channel
   },
   commands: {},
-  events: [],
+  events: {},
   loadModule: function (module) {
     moduleLoader.loadModule(self, './modules/' + module)
   },


### PR DESCRIPTION
The event includes a `self` parameter indicating that the join is related to the bot itself.

Resolves #150, Resolves #169, Resolves #151