### PR TITLE
Add Twitter feed for owo'd news stories

### DIFF
--- a/modules/news.js
+++ b/modules/news.js
@@ -129,44 +129,47 @@ module.exports = {
     news: function (bot, news) {
       console.log('NEWSNEWSNEWS', news)
       if (!oldnews[news.id] || !isEqualObj(oldnews[news.id], news)) {
-        var bitly = new Bitly(bot.config.get('bitly.username'), bot.config.get('bitly.password'))
-        bitly.shorten(news.url, function (err, res) {
-          if (err) res = { data: { url: news.url } }
-          var str = ''
-          if (news.prompt) {
-            str += colors.wrap(news.color, news.prompt + ': ')
-          }
-          // news transform
-          try {
-            if (bot.config.get('news.replace')) {
-              var substitutions = JSON.parse(read(__rootdir + '/data/substitutions.json', { encoding: 'utf-8' }))
-              var stringsToReplace = Object.keys(substitutions)
-              var newstr = news.text
-              for (var i = 0; i < stringsToReplace.length; i++) {
-                newstr = newstr.replace(stringsToReplace[i], '\x1f' + substitutions[stringsToReplace[i]] + '\x0f')
-              }
-              str += newstr
-            } else {
-              str += news.text
-            }
-            if (Math.random() <= bot.config.get('news.owo')) {
-              str = owo(str)
-            }
-          } catch (e) {
-            str += news.text + '(err)'
-          }
-          if (res.data.url) {
-            str += ' ' + colors.wrap('gray', res.data.url)
-          }
-          if (news.tail) {
-            str += ' ' + colors.wrap('magenta', '(' + news.tail + ')')
-          }
-
-          bot.broadcast(str)
-        })
-        oldnews[news.id] = news
-        write(__rootdir + '/data/news.json', JSON.stringify(oldnews))
+        bot.fireEvents('newNews', news)
       }
+    },
+    newNews: (bot, news) => {
+      var bitly = new Bitly(bot.config.get('bitly.username'), bot.config.get('bitly.password'))
+      bitly.shorten(news.url, function (err, res) {
+        if (err) res = { data: { url: news.url } }
+        var str = ''
+        if (news.prompt) {
+          str += colors.wrap(news.color, news.prompt + ': ')
+        }
+        // news transform
+        try {
+          if (bot.config.get('news.replace')) {
+            var substitutions = JSON.parse(read(__rootdir + '/data/substitutions.json', { encoding: 'utf-8' }))
+            var stringsToReplace = Object.keys(substitutions)
+            var newstr = news.text
+            for (var i = 0; i < stringsToReplace.length; i++) {
+              newstr = newstr.replace(stringsToReplace[i], '\x1f' + substitutions[stringsToReplace[i]] + '\x0f')
+            }
+            str += newstr
+          } else {
+            str += news.text
+          }
+          if (Math.random() <= bot.config.get('news.owo')) {
+            str = owo(str)
+          }
+        } catch (e) {
+          str += news.text + '(err)'
+        }
+        if (res.data.url) {
+          str += ' ' + colors.wrap('gray', res.data.url)
+        }
+        if (news.tail) {
+          str += ' ' + colors.wrap('magenta', '(' + news.tail + ')')
+        }
+
+        bot.broadcast(str)
+      })
+      oldnews[news.id] = news
+      write(__rootdir + '/data/news.json', JSON.stringify(oldnews))
     }
   }
 }

--- a/modules/twitter.js
+++ b/modules/twitter.js
@@ -1,5 +1,6 @@
 const TwitterPin = require('twitter-pin')
 const Tweeter = require('fast-tweet')
+const owo = require('@zuzak/owo')
 let twitterPin
 
 module.exports = {
@@ -30,6 +31,7 @@ module.exports = {
         })
         bot.config.set(`twitter.users.${response.screen_name}.key`, response.token)
         bot.config.set(`twitter.users.${response.screen_name}.secret`, response.secret)
+        bot.say(msg.nick, JSON.stringify(response))
         return 'authorized as ' + response.screen_name
       }
     },
@@ -48,6 +50,20 @@ module.exports = {
         let tweet = await client.tweet({ status: msg.body })
         return 'https://twitter.com/statuses/' + tweet.id_str
       }
+    }
+  },
+  events: {
+    newNews: (bot, news) => {
+      let user = bot.config.get('twitter.newsUser')
+      if (!user) return 'tweeting disabled'
+      let client = new Tweeter({
+        consumer_key: bot.config.get('twitter.keys.consumerKey'),
+        consumer_secret: bot.config.get('twitter.keys.consumerSecret'),
+        access_token_key: bot.config.get(`twitter.users.${user}.key`),
+        access_token_secret: bot.config.get(`twitter.users.${user}.secret`)
+      })
+      let url = news.url ? news.url : ''
+      client.tweet({ status: owo(news.text) + '\r\n' + url })
     }
   }
 }


### PR DESCRIPTION
somewhat predictably GitHub is suggesting @kragniz review this one

This PR adds a `newNews` event to decouple the "format and output news" stuff from the "check if news has already been output" stuff, then uses that event to send cursed news to Twitter.