### PR TITLE
Use headline + url as BBC News story id

### DIFF
--- a/modules/news.js
+++ b/modules/news.js
@@ -49,7 +49,7 @@ module.exports = {
       if (story && story.headline) {
         bot.fireEvents('news', {
           color: 'dark_red',
-          id: 'BBC' + story.assetId,
+          id: 'BBC' + story.headline + story.assetUri,
           text: story.headline,
           url: 'https://bbc.co.uk' + story.assetUri,
           prompt: 'BBC BREAKING'


### PR DESCRIPTION
The BBC seem to use one ID per story, so if there's rolling coverage
(e.g. an election night), the bot will only fire on the first story
instead of every update.

This commit changes the behaviour to report whenever any headline/url
pair changes.