### PR TITLE
Fix URL sending

### DIFF
--- a/modules/url.js
+++ b/modules/url.js
@@ -4,10 +4,10 @@ module.exports = {
   events: {
     message: function (bot, nick, to, text, msg) {
       var urls = getUrls(text)
-      if (urls.length) {
+      if (urls.size) {
         bot.fireEvents('urls', urls, nick, to, text, msg)
-        for (var i = 0; i < urls.length; i++) {
-          var curr = parseurl.parse(urls[i])
+        for (let url of urls) {
+          let curr = parseurl.parse(url)
           bot.fireEvents('url', curr, nick, to, text, msg)
           bot.fireEvents('url:' + curr.hostname, curr, nick, to, text, msg)
         }


### PR DESCRIPTION
I think the update in #144 broke things.
I'm not sure the URLs were always a set.

Anyway, turns out sets have a .size whereas arrays have a .length

Fixes #277 