### PR TITLE
Fix URL events

### DIFF
--- a/modules/url-events.js
+++ b/modules/url-events.js
@@ -69,8 +69,8 @@ var shorten = function (bot, url) {
 module.exports = {
   events: {
     url: async function (bot, url, nick, to, text, msg) {
-      bot.shout(to, Promise.all(
-        [shorten(bot, url.href), getTitle(url.href)])
+      bot.shout(to, (await Promise.all(
+        [shorten(bot, url.href), getTitle(url.href)]))
         .filter(Boolean).join(' → '))
     }
   },


### PR DESCRIPTION
`Promise.all` needs to be `await`ed when there's more than one promise to resolve. I fixed it.