### PR TITLE
Explicitly use writeFileSync because no callback

### DIFF
--- a/modules/bucket.js
+++ b/modules/bucket.js
@@ -2,7 +2,7 @@
 var inventory = []
 var inventoryLimit = 20
 var dropRate = 500
-var write = require('fs').writeFile
+var write = require('fs').writeFileSync
 
 try {
   inventory = require(__rootdir + '/data/inventory.json') || []


### PR DESCRIPTION
I think I upgraded civilservant's nodejs version so now it echoes
problems like this to console.