### PR TITLE
Add command to rescind latest Scrabble match

### DIFF
--- a/modules/scrabble.js
+++ b/modules/scrabble.js
@@ -110,6 +110,11 @@ module.exports = {
     words: {
       help: 'List the recorded high-scoring Scrabble words',
       command: () => wordHistory.map(word => computeWord(word).formatted).join(' ')
+    },
+    belay: {
+      privileged: true,
+      help: 'Removes the most recent Scrabble word from the history',
+      command: () => 'removed ' + wordHistory.pop()
     }
   },
   events: {


### PR DESCRIPTION
Occasionally we get false positives that shouldn't be stored as a real
word. This commit adds a !belay command to remove the last stored word
from the word history.

It's called !belay because I'm reading Master & Commander at the moment.