### PR TITLE
Save immediately after newNews event

### DIFF
--- a/modules/news.js
+++ b/modules/news.js
@@ -120,6 +120,8 @@ module.exports = {
     },
     news: function (bot, news) {
       if (!oldnews[news.id]) {
+        oldnews[news.id] = news
+        write(__rootdir + '/data/news.json', JSON.stringify(news))
         bot.fireEvents('newNews', news)
       }
     },
@@ -162,8 +164,6 @@ module.exports = {
       }
 
       bot.broadcast(str)
-      oldnews[news.id] = news
-      write(__rootdir + '/data/news.json', JSON.stringify(oldnews))
     }
   }
 }


### PR DESCRIPTION
Previously we saved only once all the news had been parsed and the
breaking news emitted to channels.

This meant that if there was a problem sending news to channels -- for
example, the bot was disconnected from IRC without realising it -- the
bot would never store the news in the stale log.

This was fine when there was only one medium for news, as the bot would
essentially wait until reconnected before marking news stale. However,
now we have a Twitter bot as well it means the bot will flood Twitter
every 30 second poll period.

This commit changes the log to log the actual news payload and now
actually saves the stale news immediately after firing the newNews
event, instead of just checking if unstale and leaving something later
to actually mark it as stale.

We used to store a nicely normalised news JSON blob but now just store
the payload direct from the API, so this might cause unpleasant
side-effects.

Fixes #320