### PR TITLE
npm audit

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "license": "ISC",
   "dependencies": {
-    "@zuzak/owo": "^1.0.0",
+    "@zuzak/owo": "^1.1.1",
     "airport-lookup": "^1.1.0",
     "asciify": "^1.3.5",
     "bitly": "~6.1.0",
@@ -52,7 +52,7 @@
     "rot": "^0.1.0",
     "scrape": "^0.2.3",
     "shell-escape": "^0.2.0",
-    "snyk": "^1.161.1",
+    "snyk": "^1.208.0",
     "suncalc": "^1.7.0",
     "twitter-pin": "^1.0.0",
     "underscore": "^1.8.3",
@@ -65,7 +65,7 @@
   "devDependencies": {
     "coveralls": "^3.0.3",
     "jshint": "^2.5.4",
-    "mocha": "^2.3.4",
+    "mocha": "^6.2.0",
     "mockery": "^2.1.0",
     "node-dir": "^0.1.11",
     "nyc": "^14.0.0",


### PR DESCRIPTION
Ran `npm audit` to fix a load of sketchy dependencies:

```
$ npm audit fix
npm WARN ajv-keywords@3.2.0 requires a peer of ajv@^6.0.0 but none is installed. You must install peer dependencies yourself.

+ snyk@1.208.0
added 16 packages from 21 contributors, removed 7 packages and updated 58 packages in 24.826s
fixed 54 of 57 vulnerabilities in 2724 scanned packages
  1 package update for 3 vulns involved breaking changes
  (use `npm audit fix --force` to install breaking changes; or refer to `npm audit` for steps to fix these manually)

$ npm audit fix --force
npm WARN using --force I sure hope you know what you are doing.
npm WARN ajv-keywords@3.2.0 requires a peer of ajv@^6.0.0 but none is installed. You must install peer dependencies yourself.

+ mocha@6.2.0
added 52 packages from 16 contributors, removed 9 packages and updated 7 packages in 12.421s
fixed 3 of 3 vulnerabilities in 2755 scanned packages
  1 package update for 3 vulns involved breaking changes
  (installed due to `--force` option)
```