### PR TITLE
Don't get URL title on non-200 status

### DIFF
--- a/modules/url-events.js
+++ b/modules/url-events.js
@@ -29,8 +29,11 @@ var getTitle = function (url) {
         }
       }).on('error', () => {
         // If there was an error, don't bother trying to get the title
-        // But still process the rest of the URLs
         resolve(null)
+      }).on('response', (response) => {
+        if (response.statusCode !== 200) {
+          resolve(null)
+        }
       }).on('end', () => {
         // After aborting (or finishing), parse title
         const $ = cheerio.load(response)


### PR DESCRIPTION
Fixes #345 

Presumably this will also fail on 301 etc., so maybe it should just fail on status codes ≥ 400. Discuss.
