### PR TITLE
Remove console.log of UDP buffer

### DIFF
--- a/modules/udp.js
+++ b/modules/udp.js
@@ -1,7 +1,6 @@
 module.exports = {
   events: {
     udp: function (bot, msg, rinfo) {
-      console.log(msg, rinfo)
       if (rinfo.address === bot.config.get('yakc.ip')) {
         bot.fireEvents('yakc', msg.toString(), rinfo)
       } else {


### PR DESCRIPTION
Previously all UDP messages were echoed in hex format to console. This
was fine when there was only a few UDP messages, but there's quite a few
these days.

This commit stops stdout being full of messages like:
<Buffer 03 31 30 40 41 4d 45 52 49 43 55 48 48 48 48 03 20 03 30 30>