### PR TITLE
Add option to only shout about real words

### DIFF
--- a/config.js
+++ b/config.js
@@ -237,6 +237,11 @@ module.exports = config = convict({
       doc: 'The number of points above the minScore required to respond with enthusiasm',
       format: Number,
       default: 5
+    },
+    sowpodsOnly: {
+      doc: 'Only shout about words in Sowpods',
+      format: Boolean,
+      default: true
     }
   },
   transliteration: {

--- a/modules/scrabble.js
+++ b/modules/scrabble.js
@@ -125,8 +125,9 @@ module.exports = {
       phrase.forEach((word) => {
         word = word.replace(/[^A-Za-z]+$/, '')
         let result = computeWord(word)
-        if (wordHistory.map(word => word.toUpperCase()).includes(word.toUpperCase()) ||
-          !result.isPossible) return
+        if (wordHistory.map(word => word.toUpperCase()).includes(word.toUpperCase())) return
+        if (!result.isPossible) return
+        if (bot.config.get('scrabble.sowpodsOnly') && !result.isAllowable) return
         words.push(result)
       })
       const bestWord = words.reduce((a, b) => (a.score > b.score) ? a : b, 0)


### PR DESCRIPTION
Adds `scrabble.sowpodsOnly` setting. Setting this to `true` will only shout about words in Sowpods; `false` retains the current behaviour. I set the default to `true` here, but that's open to discussion.

This should stop the bot from getting excited about typos and random strings that aren't real words, while still congratulating users on their excellent verbiage.

The behaviour of the `!scrabble` command is unchanged.