### PR TITLE
Fix agc argument passing

### DIFF
--- a/modules/irclog.js
+++ b/modules/irclog.js
@@ -57,7 +57,7 @@ module.exports = {
     irccount: {
       help: 'count the occurences of a string in the irc logs',
       privileged: true,
-      aliases: [ 'agc', 'ircc', 'irclogc' ],
+      aliases: ['agc', 'ircc', 'irclogc'],
       command: async function (bot, msg) {
         if (msg.args.length === 1) {
           return 'Usage: !irclog <search phrase>'

--- a/modules/irclog.js
+++ b/modules/irclog.js
@@ -50,7 +50,7 @@ module.exports = {
         if (msg.args.length === 1) {
           return 'Usage: !irclog <search phrase>'
         }
-        const res = await logExec([__rootdir + '/irclog.sh', msg.body])
+        const res = await logExec(`${__rootdir}/irclog.sh ${esc(msg.body)}`)
         return processAg(res)
       }
     },
@@ -63,7 +63,7 @@ module.exports = {
           return 'Usage: !irclog <search phrase>'
         }
         if (!bot.config.has('irclogs')) return 'Error: No logfile specified'
-        const res = await logExec(['ag', '-c', '--', msg.body, bot.config.get('irclogs')])
+        const res = await logExec(`ag -c -- ${esc(msg.body)} ${bot.config.get('irclogs')}`)
         return processAg(res)
       }
     }


### PR DESCRIPTION
I think we deleted the shell escape stuff for some reason.
This puts it back, in a more limited fashion.