### PR TITLE
Update random.js

### DIFF
--- a/modules/random.js
+++ b/modules/random.js
@@ -5,12 +5,11 @@ module.exports = {
       command: function (bot, msg) {
         if (msg.args.length > 2) {
           msg.args.shift()
-          const randint = msg.args[Math.floor(Math.random() * msg.args.length)]
-          return randint.toString()
+          return msg.args[Math.floor(Math.random() * msg.args.length)]
         } else if (msg.args.length === 2) {
           var res = Math.floor(Math.random() * Math.floor(msg.args[1]))
           if (!isNaN(res)) {
-            return res
+            return res.toString
           }
         }
         return 'Usage: (<number>|<choice 1> … <choice n>)'

--- a/modules/random.js
+++ b/modules/random.js
@@ -9,7 +9,7 @@ module.exports = {
         } else if (msg.args.length === 2) {
           var res = Math.floor(Math.random() * Math.floor(msg.args[1]))
           if (!isNaN(res)) {
-            return res.toString
+            return res.toString()
           }
         }
         return 'Usage: (<number>|<choice 1> … <choice n>)'


### PR DESCRIPTION
Fixed #396 - Removed pointless conversion and var and added conversion to var 'res' - This is because the handler can't interpreit vars with properties other than string.

This is a greater problem and should probably be re-visited, as the handler should be able to interpret all reasonable var types (especially number and bool).