### PR TITLE
Remove Bloomberg news stories fully

### DIFF
--- a/modules/news.js
+++ b/modules/news.js
@@ -77,21 +77,6 @@ module.exports = {
         url: item.link
       })
     },
-    'rawnews:bloomberg': function (bot, stories) {
-      for (var i = 0; i < stories.length; i++) {
-        var story = stories[i]
-        if (story) {
-          bot.fireEvents('news', {
-            color: 'purple',
-            id: 'bbrg' + story.toString(),
-            text: JSON.stringify(story),
-            url: null,
-            prompt: stories.editorialTitle,
-            tail: 'Bloomberg (test)'
-          })
-        }
-      }
-    },
     'rawnews:reuwire': function (bot, stories) {
       for (let i = 0; i < stories.length; i++) {
         const story = stories[i]

--- a/plugins/news.js
+++ b/plugins/news.js
@@ -13,30 +13,6 @@ function APIs (loud) {
       url: 'http://www.aljazeera.com/addons/alert.ashx',
       eventName: 'aljaz'
     },
-    /* { // Bloomberg seems blocked by CAPTCHAs
-      url: 'https://www.bloomberg.com/api/modules/id/africa_breaking_news',
-      eventName: 'bloomberg',
-      payload: {tag: 'Africa'}
-    },
-    {
-      url: 'https://www.bloomberg.com/api/modules/id/canada_breaking_news',
-      eventName: 'bloomberg',
-      payload: {tag: 'Canada'}
-    },
-    {
-      url: 'https://www.bloomberg.com/api/modules/id/europe_breaking_news',
-      eventName: 'bloomberg',
-      payload: {tag: 'Europe'}
-    },
-    {
-      url: 'https://www.bloomberg.com/api/modules/id/us_breaking_news',
-      eventname: 'bloomberg',
-      payload: {tag: 'us'}
-    },
-    {
-      url: 'https://www.bloomberg.com/api/modules/id/breaking_news',
-      eventname: 'bloomberg'
-    }, */
     {
       url: 'http://polling.bbc.co.uk/news/latest_breaking_news_waf?audience=Domestic',
       eventName: 'bbc',


### PR DESCRIPTION
The Bloomberg stuff's been gated behind a CAPTCHA for a while, so we may
as well remove it entirely.