### PR TITLE
Tweet source name if no URL

### DIFF
--- a/modules/news.js
+++ b/modules/news.js
@@ -52,6 +52,7 @@ module.exports = {
           id: 'BBC' + story.headline + story.assetUri,
           text: story.headline,
           url: 'https://bbc.co.uk' + story.assetUri,
+          source: 'BBC',
           prompt: 'BBC BREAKING'
         })
       }
@@ -64,6 +65,7 @@ module.exports = {
         prompt: story.label ? story.label : 'Reuters',
         tail: story.tag ? story.tag : null,
         text: story.headline,
+        source: 'Reuters',
         url: story.url ? story.url : null
       })
     },
@@ -74,6 +76,7 @@ module.exports = {
         id: item.guid,
         prompt: feed.feed.title,
         text: item.content,
+        source: 'Security Service',
         url: item.link
       })
     },
@@ -85,6 +88,7 @@ module.exports = {
           id: story.id,
           text: story.headline,
           prompt: 'Reuters',
+          source: 'Reuters',
           url: 'http://www.reuters.com' + story.url
         })
       }
@@ -98,6 +102,7 @@ module.exports = {
             id: curr.GUID,
             prompt: 'Al Jazeera ' + curr.Type,
             text: curr.Text,
+            source: 'Al Jazeera',
             url: curr.Url
           })
         }

--- a/modules/twitter.js
+++ b/modules/twitter.js
@@ -72,7 +72,21 @@ module.exports = {
       if (!bot.config.has('twitter.newsUser')) return undefined
       const user = bot.config.get('twitter.newsUser')
       if (!user) return 'tweeting disabled'
-      const url = news.url ? news.url : ''
+      let url
+      try {
+        url = new URL(url)
+      } catch (e) {
+        if (e.code === 'ERR_INVALID_URL') {
+          if (news.source) {
+            url = `- ${news.source}`
+          } else {
+            url = ''
+          }
+        } else {
+          throw e
+        }
+      }
+
       bot.tweet(user, { status: owo(news.text) + '\r\n' + url })
     }
   }


### PR DESCRIPTION
This commit adds a check on the URL parameter to ensure it is actually a
URL; if it isn't, it won't tweet it. Reuters have previously put prose
in the "url" field, which means that they get tweeted out without being
owoified.

This commit also adds functionality to tweet out the news source if
there's no URL yet.