### PR TITLE
Fix countdown

### DIFF
--- a/modules/countdown.js
+++ b/modules/countdown.js
@@ -29,7 +29,7 @@ function autoCount (bot, lastTick) {
   const { name, date } = nextBrexitDate()
   const thisTick = moment(date).countdown().toString().split(/, | and /)[0]
   if (lastTick != null && thisTick !== lastTick) {
-    bot.broadcast(`${name} expires in ${moment(date).countdown()}`)
+    bot.broadcast(`${name} expires in ${lastTick}`)
   }
   timeout = setTimeout(autoCount, 1000, bot, thisTick)
 }


### PR DESCRIPTION
The bot is annoyingly saying things like
```
Notice(civilservant): Article 50 expires in 18 hours, 59 minutes and 59 seconds
```

This is a regression from when it used to say
```
Notice(civilservant): Article 50 expires in 19 hours
```

This PR restores that behaviour.